### PR TITLE
ENH: add requirements for pip-installable package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
+include LICENSE
+include MANIFEST.in
+include README.md
+include requirements.txt
+include setup.py
 include versioneer.py
 include xray_vision/_version.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+matplotlib
+numpy
+pandas
+pyqt
+scipy
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
 numpy
 pandas
-pyqt
+pyqt5
 scipy
 six

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ except ImportError:
 import setuptools
 import versioneer
 
+with open('requirements.txt') as f:
+    requirements = f.read().split()
 
 setup(
     name='xray-vision',
@@ -18,4 +20,5 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     author='Brookhaven National Lab',
     packages=setuptools.find_packages(),
+    install_requires=requirements,
 )


### PR DESCRIPTION
Based on our [lightsource2-tag conda recipe](https://github.com/NSLS-II/lightsource2-recipes/blob/1757decd5025eacfc072b63ac93d1d02ef4ba3f3/recipes-tag/xray-vision/meta.yaml#L21-L26).

Closes #91.