### PR TITLE
BLD: add PyPI description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Domain specific plotting and GUI widgets for X-ray science
 
 Install the most recent tagged build: `conda install xray-vision -c lightsource2-tag`
 
-Install the most recent tagged build: `conda install xray-vision -c lightsource2-dev`
+Install the most recent development build: `conda install xray-vision -c lightsource2-dev`
 
 Find the tagged recipe [here](https://github.com/NSLS-II/lightsource2-recipes/tree/master/recipes-tag/xray-vision) and the dev recipe [here](https://github.com/NSLS-II/lightsource2-recipes/tree/master/recipes-dev/xray-vision)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     name='xray-vision',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    author='Brookhaven National Lab',
+    author='Brookhaven National Laboratory',
     description='Visualization widgets and plotting helpers targeted at X-Ray Sciences',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,18 @@ import versioneer
 with open('requirements.txt') as f:
     requirements = f.read().split()
 
+with open('README.md') as f:
+    long_description = f.read()
+
 setup(
     name='xray-vision',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     author='Brookhaven National Lab',
+    description='Visualization widgets and plotting helpers targeted at X-Ray Sciences',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=setuptools.find_packages(),
     install_requires=requirements,
+    url='https://github.com/Nikea/xray-vision',
 )


### PR DESCRIPTION
Targeting v0.0.9 with PyPI description. Currently it's empty: https://pypi.org/project/xray-vision/.

Instructions are found at https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py, answering [my question](https://github.com/Nikea/xray-vision/pull/92#issuecomment-398900020).